### PR TITLE
New default breakpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ First, in your `main.js`, set up your media queries
 import { setup } from 'svelte-match-media'
 
 setup({
-  desktop: 'screen and (min-width: 769px)',
-  mobile: 'screen and (max-width: 768px)'
+  desktop: 'screen and (min-width: 768px)',
+  mobile: 'screen and (max-width: 767px)'
 })
 
 // or if those are the exact media queries you want, just call setup()

--- a/index.js
+++ b/index.js
@@ -9,8 +9,8 @@ const setupMq = (queryString) => (set) => {
 }
 
 const defaultQueries = {
-  desktop: 'screen and (min-width: 769px)',
-  mobile: 'screen and (max-width: 768px)'
+  desktop: 'screen and (min-width: 768px)',
+  mobile: 'screen and (max-width: 767px)'
 }
 
 let queryStores


### PR DESCRIPTION
Can I suggest you to change default media queries with this instead?

```js
setup({
  desktop: 'screen and (min-width: 768px)',
  mobile: 'screen and (max-width: 767px)'
})
```

From 768  to 769; from 768 to 767.

Many css frameworks have these default breakpoints:

1. Bootstrap: https://getbootstrap.com/docs/4.5/layout/grid/

1. TailwindCSS: https://tailwindcss.com/docs/responsive-design/